### PR TITLE
Bump dependencies and update project configuration and enhance some test with serde 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ catalyser = { path = "catalyser" }
 
 [workspace.package]
 authors = ["gouvinb"]
-edition = "2021"
+edition = "2024"
 categories = ["rust-patterns"]
 license-file = "LICENSE.md"
 readme = "README.md"

--- a/catalyser/Cargo.toml
+++ b/catalyser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "catalyser"
 description = "A comprehensive collection of extensions to simplify and enhane rust development."
-version = "0.1.0"
+version = "0.1.1"
 keywords = [
     "utils",
     "std",

--- a/catalyser/Cargo.toml
+++ b/catalyser/Cargo.toml
@@ -16,10 +16,10 @@ repository.workspace = true
 
 
 [dependencies]
-serde = { version = "1.0.216", features = ["derive"], optional = true }
+serde = { version = "1.0.219", features = ["derive"], optional = true }
 
 [dev-dependencies]
-serde_json = { version = "1.0.134" }
+serde_json = { version = "1.0.142" }
 
 [features]
 default = []

--- a/catalyser/src/stdx/collections.rs
+++ b/catalyser/src/stdx/collections.rs
@@ -133,6 +133,7 @@ mod tests {
     // the expanded macro-generated code for better understanding and debugging.
 
     use super::*;
+    #[cfg(feature = "serde")]
     use serde_json;
 
     #[test]
@@ -278,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_nonempty_collection_serde() {
         let data_vec = vec![1, 2, 3];
 

--- a/catalyser/src/stdx/string.rs
+++ b/catalyser/src/stdx/string.rs
@@ -289,7 +289,8 @@ mod tests {
     }
 
     #[test]
-    fn test_serde_non_empty_string() {
+    #[cfg(feature = "serde")]
+    fn test_non_empty_string_serde() {
         let input = "Serialize Test".to_string();
         let non_empty = NonEmptyString::new(input.clone()).unwrap();
 
@@ -303,7 +304,8 @@ mod tests {
     }
 
     #[test]
-    fn test_serde_non_blank_string() {
+    #[cfg(feature = "serde")]
+    fn test_non_blank_string_serde() {
         let input = "Serialize Test".to_string();
         let non_blank = NonBlankString::new(input.clone()).unwrap();
 


### PR DESCRIPTION
### Summary

This pull request includes the following changes:

- Bump the project version to `0.1.1` in `Cargo.toml`.
- Upgrade the `serde` and `serde_json` dependencies to newer versions in `Cargo.toml`.
- Update the Cargo edition to `2024` for compatibility with the latest Rust tools.
- Add conditional `serde` attributes to tests in `stdx` modules for better flexibility and compatibility.

### Checklist

- [x] Tests added or updated where applicable.
- [x] Version updated in relevant files.
- [x] Dependencies updated.
